### PR TITLE
[FIX] 유저 검색시 프로그램이 종료되는 버그 수정

### DIFF
--- a/BojRankApp/Service/BojService.cs
+++ b/BojRankApp/Service/BojService.cs
@@ -143,7 +143,7 @@ namespace BojRankApp.Service
             string path = "users.txt";
             
             if (!File.Exists(path))
-                return null;
+                return new ObservableCollection<User>();
 
             string json = File.ReadAllText(path);
             var users = JsonSerializer.Deserialize<List<User>>(json);

--- a/BojRankApp/ViewModel/UserViewModel.cs
+++ b/BojRankApp/ViewModel/UserViewModel.cs
@@ -40,26 +40,27 @@ namespace BojRankApp.ViewModel
         {
             bojService = new BojService();
             Problems = new ObservableCollection<SolvedProblem>();
-            Users = new ObservableCollection<User>();
             Users = bojService.LoadFile();
         }
 
         [RelayCommand]
         public async Task AddUser(string userId)
         {
-            User user = await bojService.LoadUser(userId);
-            var target = Users.FirstOrDefault(u => u.Id == userId);
 
+            var target = Users.FirstOrDefault(u => u.Id == userId);
+            if (target != null)
+            {
+                MessageBox.Show("이미 존재하는 사용자입니다.");
+                return;
+            }
+
+            User user = await bojService.LoadUser(userId);
             if (user == null)
             {
                 MessageBox.Show("사용자를 찾을 수 없습니다.");
                 return;
             }
-            else if(target != null)
-            {
-                MessageBox.Show("이미 있는 사용자입니다.");
-                return;
-            }
+
             Users.Add(user);
             SelectedUser = user;
             bojService.SaveFile(Users);


### PR DESCRIPTION
- Users에 Null이 들어가는 경우 버그가 발생하므로 Null이 들어가지 않도록 해결
- 유저를 검색(api 호출)하기 전에 file에 존재하는 사용자일 경우 중복처리

## 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
closed #31 
## ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
-  유저 검색시 프로그램이 종료되는 버그 수정
## 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- 